### PR TITLE
Add ParseComments flag

### DIFF
--- a/goastpy/main.go
+++ b/goastpy/main.go
@@ -28,7 +28,7 @@ func main() {
 // of the abstract syntax tree (AST) in byte format.
 func parseSourceCode(code string) []byte {
 	fileSet := token.NewFileSet()
-	file, _ := parser.ParseFile(fileSet, "main.go", code, 0)
+	file, _ := parser.ParseFile(fileSet, "main.go", code, parser.ParseComments)
 	astMap := traverseAST(fileSet, file)
 	result, _ := json.Marshal(astMap)
 	return result


### PR DESCRIPTION
This change will instruct the parser to include comments in the AST. Including the comments to the AST node can be useful for building self documenting code algos (which is my use case). This flag specifically instructs the parser to include comments in the AST, which would be necessary where analyzing comments might be relevant